### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/still.php
+++ b/still.php
@@ -32,7 +32,7 @@ $command = 'raspistill  --nopreview -o /opt/temp/test01.jpg '.$quality.$width.$h
 
 $escaped_command = escapeshellcmd($command);
  
-exec($command, $test, $retval);
+exec($escaped_command, $test, $retval);
 #echo '<p>'.$command.'</p>';
 echo '<p>'.implode ( '</p><p>' , $test ).'</p>';
 echo "<img src='image.jpg'/>";


### PR DESCRIPTION
Currently, the escaped_command variable is not really used in exec allowing command injection attack.

```php
$command = 'raspistill  --nopreview -o /opt/temp/test01.jpg '.$quality.$width.$height.$verbose.$timeout.$encoding.$timelapse.$sharpness.$contrast.$saturation.$ISO.$vstab.$ev.$exposure.$awb.$imxfx.$colfx.$metering.$rotation.$hflip.$vflip.'  2>&1  '  ;

$escaped_command = escapeshellcmd($command);
 
exec($command, $test, $retval);
```

Pull request will use the escaped_command variable in the exec command therefore eliminating the command-line injection vulnerability.